### PR TITLE
make keyword coloring consistent

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -77,7 +77,7 @@ atom-text-editor {
 }
 
 .keyword {
-        color: @red;
+        color: @purple;
         &.control {
                 color: @purple;
         }


### PR DESCRIPTION
In Julia, without this, some keywords like `module` and `function` are colored differently than their `end`, resulting in an unpleasant asymmetry. 

![image](https://user-images.githubusercontent.com/1510968/32542968-946bcd88-c474-11e7-93b6-2d4fd4d70f35.png)

This fixes that, and also makes the coloring consistent with e.g. how its done in [One Dark](https://github.com/atom/one-dark-syntax/blob/15cc53b7852c9ecf5a5a880115ad61b7fca90ecd/styles/syntax/_base.less#L23-L28) and with how it looks with One Dork in jupyterthemes. 

See also: https://github.com/JuliaEditorSupport/atom-language-julia/issues/127